### PR TITLE
RFC0013 - Entry point placement

### DIFF
--- a/Specification/EntryPoint.md
+++ b/Specification/EntryPoint.md
@@ -7,11 +7,13 @@ This RFC describes the entry point of application-style projects. Note, that the
 The entry point has to be a free-function named `main` (case-sensitive). The allowed parameterization/return types:
  * `func main(): unit`
  * `func main(): int32`, where the returned value is the exit code of the application
+ 
+ The visibility of the `main` function doesn't matter.
 
 A future RFC will add the possibility to take a string array as a parameter for the CLI arguments. This has to wait until the array type syntax is specified.
 
 ## Placement in the project
 
-The exact details will have to wait for the module system specification, but the entry point will likely have to be placed in the main, top-level module file.
+The entry point must be placed in a file `main.draco` in the root module of a package.
 
 The rationale behind this is to introduce a convention to easily navigate to the true entry point of the application. Many C# projects already used `Program.cs` for this as a soft convention.


### PR DESCRIPTION
This RFC specifies the placement of the application entry point in a draco project.